### PR TITLE
Fix the maximum recursion error

### DIFF
--- a/servo-test.py
+++ b/servo-test.py
@@ -347,7 +347,10 @@ class MainWindow(QMainWindow):
     def scan_for_servos(self, port):
         self.setCursor(Qt.CursorShape.WaitCursor)
 
-        LX16A.initialize(port)
+        try:
+            LX16A.initialize(port)
+        except:
+            pass
 
         self.id_selection_box.clear()
 


### PR DESCRIPTION
Some users experience the maximum recursion error with servo-test.py. Decorator runs recursively without bound trying to search for servos on empty or inaccessible ports. This change fixes the bug.